### PR TITLE
fix: Use VITE_BACKEND_URL environment variable

### DIFF
--- a/frontend/src/lib/axios.js
+++ b/frontend/src/lib/axios.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 
 export const axiosInstance = axios.create({
-  baseURL: import.meta.env.BACKEND_URL,
+  baseURL: import.meta.env.VITE_BACKEND_URL,
   withCredentials: true,
 });

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,12 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:5000",
+        changeOrigin: true,
+      },
+    },
+  },
+});


### PR DESCRIPTION
This commit fixes the issue where the frontend was sending API requests to itself instead of the backend. This was caused by the incorrect environment variable being used. The code has been updated to use `VITE_BACKEND_URL` as required by Vite.

Additionally, a proxy has been added to the Vite configuration to make local development easier and avoid CORS issues.