### PR TITLE
feat: Separate frontend and backend for Vercel deployment

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -20,7 +20,7 @@ app.use(express.json());
 app.use(cookieParser());
 app.use(
   cors({
-    origin: process.env.FRONTEND_URL,
+    origin: [process.env.FRONTEND_URL, "https://chatty-iota.vercel.app"],
     credentials: true,
   })
 );
@@ -28,13 +28,6 @@ app.use(
 app.use("/api/auth", authRoutes);
 app.use("/api/messages", messageRoutes);
 
-if (process.env.NODE_ENV === "production") {
-  app.use(express.static(path.join(__dirname, "../frontend/dist")));
-
-  app.get("*", (req, res) => {
-    res.sendFile(path.join(__dirname, "../frontend", "dist", "index.html"));
-  });
-}
 
 server.listen(PORT, () => {
   console.log("server is running on PORT:" + PORT);

--- a/backend/src/lib/socket.js
+++ b/backend/src/lib/socket.js
@@ -7,7 +7,7 @@ const server = http.createServer(app);
 
 const io = new Server(server, {
   cors: {
-    origin: [process.env.FRONTEND_URL],
+    origin: [process.env.FRONTEND_URL, "https://chatty-iota.vercel.app"],
   },
 });
 

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL=https://chatty-backend-pgql.onrender.com

--- a/frontend/src/store/useAuthStore.js
+++ b/frontend/src/store/useAuthStore.js
@@ -3,7 +3,7 @@ import { axiosInstance } from "../lib/axios.js";
 import toast from "react-hot-toast";
 import { io } from "socket.io-client";
 
-const BASE_URL = import.meta.env.BACKEND_URL;
+const BASE_URL = import.meta.env.VITE_BACKEND_URL;
 
 export const useAuthStore = create((set, get) => ({
   authUser: null,

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "chatty",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "dev": "npm run dev --prefix backend",
+    "build": "npm run build --prefix frontend",
+    "start": "npm start --prefix backend"
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "frontend/package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "frontend/dist"
+      }
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/frontend/dist/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
- Decouple frontend and backend to allow for separate deployments.
- Configure Vercel to build and serve the frontend application.
- Update backend CORS settings to allow requests from the Vercel frontend.
- Add a root package.json to manage both applications.